### PR TITLE
Inform user when ingest workflow done

### DIFF
--- a/app/jobs/ingest_workflow_monitor_job.rb
+++ b/app/jobs/ingest_workflow_monitor_job.rb
@@ -16,8 +16,9 @@ class IngestWorkflowMonitorJob < ActiveJob::Base
   #   If the event is retry, a new monitoring job is scheduled to run in 15 minutes.
   #   If event is failed, we mark the workflow as stopped and schedule no new jobs.
 
-  def perform(workflow_id)
+  def perform(workflow_id, params)
     @flow = IngestWorkflow.find(workflow_id)
+    @params = params
     return if done?
     continue if retry?
     retry_later if retry? or flow.running?
@@ -38,13 +39,17 @@ class IngestWorkflowMonitorJob < ActiveJob::Base
 
   def failed?
     flow.failed? && job_event.include?('failed')
-    
+
   end
 
   def done?
-    return true if flow.finished?
+    if flow.finished?
+      inform_user
+      return true
+    end
     if failed?
       log_failure
+      inform_user
       true
     else
       false
@@ -70,5 +75,32 @@ class IngestWorkflowMonitorJob < ActiveJob::Base
   #    if so, this method could raise an error and use Sidekiq's retry functionality instead
   def retry_later
     IngestWorkflowMonitorJob.set(wait: 15.minutes).perform_later(flow.id)
+  end
+
+  def inform_user
+    # params need to cointain item_id, item_name, status, message, unlink
+    u_params = {
+      item_id: @params[:item_id],
+      item_name: @params[:item_name],
+      unlink: true # remove collaborator link
+    }
+    if flow.finished?
+      u_params[:status] = 'Done - ingest successful'
+      u_params[:message] = "The package has been ingested successfully.\nDuring ingest the following steps are performed\n
+      1. Transfer a package through archivematica \n
+      2. Create a digital archival object in Hyrax \n
+      3. Create digital objects in Hyrax \n
+      4. Create entries in CALM\n
+      Details of the job can be viewed at #{ENV['SERVER_URL']}/ingests/#{flow.id}"
+    elsif failed?
+      u_params[:status] = 'Done - ingest failed'
+      u_params[:message] = "There was an error when ingesting the package.\nDuring ingest the following steps are performed\n
+      1. Transfer a package through archivematica \n
+      2. Create a digital archival object in Hyrax \n
+      3. Create digital objects in Hyrax \n
+      4. Create entries in CALM\n
+      Details of the job can be viewed at #{ENV['SERVER_URL']}/ingests/#{flow.id}"
+    end
+    Box::InformUserJob.perform_later(u_params)
   end
 end

--- a/app/jobs/review_submission_job.rb
+++ b/app/jobs/review_submission_job.rb
@@ -47,20 +47,21 @@ class ReviewSubmissionJob < Gush::Job
     end
 
     def inform_user
-      # params need to cointain item_id, item_name, status, message, unlink
+      # params need to contain item_id, item_name, status, message, unlink
       u_params = {
         item_id: params[:item_id],
-        item_name: params[:item_name],
-        unlink: true # remove collaborator link
+        item_name: params[:item_name]
       }
       if @processor.status == false and @processor.errors.any?
         u_params[:status] = 'review_failed'
         u_params[:message] = @processor.errors
+        u_params[:unlink] = true # remove collaborator link
       else
         u_params[:status] = 'processing'
         u_params[:message] = 'Successfully reviewed submission package. It is ready to be processed for archiving'
+        u_params[:unlink] = false # do not remove collaborator link
       end
-      Box::InformUserJob.perform_now(u_params)
+      Box::InformUserJob.perform_later(u_params)
     end
 end
 

--- a/app/workflows/ingest_workflow_manager.rb
+++ b/app/workflows/ingest_workflow_manager.rb
@@ -4,7 +4,8 @@ class IngestWorkflowManager
   # @params Hash of params. Required params are
   #   item_id, item_name, source_dir, number_of_works
   def initialize(params: {})
-    @flow = IngestWorkflow.create(params)
+    @params = params
+    @flow = IngestWorkflow.create(@params)
     flow.start!
     monitor
   end
@@ -12,6 +13,6 @@ class IngestWorkflowManager
   # Monitor the workflow for retry events
   #  delay start to give the start and approve jobs time to run
   def monitor
-    IngestWorkflowMonitorJob.set(wait: 1.minute).perform_later(flow.id)
+    IngestWorkflowMonitorJob.set(wait: 1.minute).perform_later(flow.id, @params)
   end
 end

--- a/spec/jobs/ingest_workflow_monitor_job_spec.rb
+++ b/spec/jobs/ingest_workflow_monitor_job_spec.rb
@@ -1,6 +1,12 @@
 RSpec.describe IngestWorkflowMonitorJob do
   let(:workflow) { double }
-  let(:ingest_wf_monitor) { described_class.new('id') }
+  let(:params) {{
+    item_id: 'item_id',
+    item_name: 'test_dir',
+    source_dir: 'test_dir',
+    number_of_works: 10
+  }}
+  let(:ingest_wf_monitor) { described_class.new('id', params) }
 
   describe 'workflow' do
     before do
@@ -14,6 +20,7 @@ RSpec.describe IngestWorkflowMonitorJob do
         allow(workflow).to receive(:mark_as_stopped)
 
         allow(ingest_wf_monitor).to receive(:log_failure)
+        allow(ingest_wf_monitor).to receive(:inform_user)
         allow(ingest_wf_monitor).to receive(:failed?).and_return(true)
       end
       it 'returns without running continue or retry' do
@@ -28,9 +35,10 @@ RSpec.describe IngestWorkflowMonitorJob do
         allow(workflow).to receive(:failed?).and_return(true)
         allow(workflow).to receive(:finished?).and_return(false)
         allow(workflow).to receive(:mark_as_stopped)
-
         allow(ingest_wf_monitor).to receive(:log_failure)
+        allow(ingest_wf_monitor).to receive(:inform_user)
         allow(ingest_wf_monitor).to receive(:failed?).and_return(true)
+
       end
       it 'returns without running continue or retry' do
         expect(ingest_wf_monitor).not_to receive(:continue)

--- a/spec/workflows/ingest_workflow_manager_spec.rb
+++ b/spec/workflows/ingest_workflow_manager_spec.rb
@@ -1,5 +1,11 @@
 RSpec.describe IngestWorkflowManager do
   let(:workflow) { double }
+  let(:params) {{
+    item_id: 'item_id',
+    item_name: 'test_dir',
+    source_dir: 'test_dir',
+    number_of_works: 10
+  }}
 
   describe 'Workflow Manager' do
     before do
@@ -7,13 +13,13 @@ RSpec.describe IngestWorkflowManager do
       allow(workflow).to receive(:start!)
       allow(workflow).to receive(:id).and_return('id')
       allow(IngestWorkflowMonitorJob).to receive(:set).with(wait: 1.minute).and_return(IngestWorkflowMonitorJob)
-      allow(IngestWorkflowMonitorJob).to receive(:perform_later)
+      allow(IngestWorkflowMonitorJob).to receive(:perform_later).with('id', params)
     end
     it 'sets up the workflow' do
-      expect(IngestWorkflow).to receive(:create).with({})
+      expect(IngestWorkflow).to receive(:create).with(params)
       expect(IngestWorkflowMonitorJob).to receive(:set).with(wait: 1.minute)
-      expect(IngestWorkflowMonitorJob).to receive(:perform_later).with(workflow_id: 'id')
-      described_class.new(params: {})
+      expect(IngestWorkflowMonitorJob).to receive(:perform_later).with('id', params)
+      described_class.new(params: params)
     end
   end
 end


### PR DESCRIPTION
I previously removed the hull_archivist as a collaborator after review, which was the last step during which we informed the user.

I now inform the user at the end of the ingest workflow and remove the hull_archivist as a collaborator as this is now the last step during which we .need to  inform the user and have access to the box directory to do so