### PR TITLE
Modify perform now to perform later when scheduling inform user jobss

### DIFF
--- a/app/jobs/transfer_workflow_monitor_job.rb
+++ b/app/jobs/transfer_workflow_monitor_job.rb
@@ -43,7 +43,7 @@ class TransferWorkflowMonitorJob < ActiveJob::Base
       u_params[:unlink] = true # remove collaborator link
       u_params[:message] = log_failure
     end
-    Box::InformUserJob.perform_now(u_params)
+    Box::InformUserJob.perform_later(u_params)
   end
 
   # Continue a failed transfer

--- a/app/workflows/transfer_workflow_manager.rb
+++ b/app/workflows/transfer_workflow_manager.rb
@@ -48,7 +48,7 @@ class TransferWorkflowManager
     u_params[:status] = 'transfering'
     u_params[:unlink] = false # do not remove collaborator link
     u_params[:message] = 'Starting file transfer'
-    Box::InformUserJob.perform_now(u_params)
+    Box::InformUserJob.perform_later(u_params)
   end
 
 end


### PR DESCRIPTION
I just noticed that I call perform_now when scheduling inform_user jobs. Changed those to perform_later, as it is preferred to queue the jobs and let sidekiq act on them asap.